### PR TITLE
simplify the integration of the state estimation

### DIFF
--- a/Inc/Sim_Con/flight_phase_detection.h
+++ b/Inc/Sim_Con/flight_phase_detection.h
@@ -1,4 +1,4 @@
-#include "../Util/util.h"
+#include "state_est_const.h"
 #include "env.h"
 
 #ifndef FLIGHT_PHASE_DETECTION_H_

--- a/Inc/Sim_Con/state_est.h
+++ b/Inc/Sim_Con/state_est.h
@@ -19,8 +19,19 @@ typedef struct extrapolation_rolling_memory_t {
     double polyfit_coeffs[EXTRAPOLATION_POLYFIT_DEGREE+1]; /* array size needs to be the degree of the polyfit plus 1 */
 } extrapolation_rolling_memory_t;
 
-void calibrate_state_est(float p_g, float T_g, flight_phase_detection_t *flight_phase_detection, state_est_data_t *state_est_data, 
-						env_t *env, kf_state_t *kf_state, extrapolation_rolling_memory_t *baro_roll_mem);
+typedef struct state_est_state_t {
+    state_est_data_t state_est_data;
+    state_est_meas_t state_est_meas;
+    state_est_meas_t state_est_meas_prior;
+    kf_state_t kf_state;
+    env_t env;
+    flight_phase_detection_t flight_phase_detection;
+    extrapolation_rolling_memory_t baro_roll_mem;
+} state_est_state_t;
+
+void reset_state_est_state(float p_g, float T_g, state_est_state_t *state_est_state);
+
+void state_est_step(timestamp_t t, state_est_state_t *state_est_state, bool bool_detect_flight_phase);
 
 void update_state_est_data(state_est_data_t *state_est_data, kf_state_t *kf_state);
 

--- a/Inc/Sim_Con/state_est_const.h
+++ b/Inc/Sim_Con/state_est_const.h
@@ -1,5 +1,3 @@
-#include "../Util/util.h"
-
 #ifndef STATE_EST_CONST_H
 #define STATE_EST_CONST_H
 
@@ -13,6 +11,24 @@
 #define USE_SENSOR_ELIMINATION_BY_EXTRAPOLATION 0 // set to 1 to activate sensor elimination by extrapolation for barometer and temperature
 #define EXTRAPOLATION_POLYFIT_DEGREE 2
 
+/* as we don't include cmsis_os.h, we need to define some datatypes ourselves */
+typedef u_int8_t uint8_t;
+typedef u_int16_t uint16_t;
+typedef u_int32_t uint32_t;
+
+/** BASIC TYPES **/
+
+/* Timestamp */
+typedef uint32_t timestamp_t;
+
+typedef enum {
+	IDLE = 1, AIRBRAKE_TEST, THRUSTING, COASTING, DESCENT, BALLISTIC_DESCENT, RECOVERY
+} flight_phase_e;
+
+/* Mach Regime */
+typedef enum {
+	SUBSONIC = 1, TRANSONIC, SUPERSONIC
+} mach_regime_e;
 
 typedef struct {
 	float pressure;
@@ -34,5 +50,22 @@ typedef struct {
     /* all in rocket frame where x-dir is along length of rocket */
 	imu_state_est_t imu_data[NUM_SENSORBOARDS];
 } state_est_meas_t;
+
+/* State Estimation Output */
+typedef struct {
+	int32_t position_world[3];
+	int32_t velocity_rocket[3];
+	int32_t acceleration_rocket[3];
+	int32_t velocity_world[3];
+	int32_t acceleration_world[3];
+} state_est_data_t;
+
+/* FSM States */
+typedef struct {
+	flight_phase_e flight_phase;
+	mach_regime_e mach_regime;
+	float mach_number;
+	int8_t num_samples_positive;
+} flight_phase_detection_t;
 
 #endif

--- a/Inc/Util/util.h
+++ b/Inc/Util/util.h
@@ -8,12 +8,7 @@
 #ifndef INC_UTIL_UTIL_H_
 #define INC_UTIL_UTIL_H_
 
-//#include "cmsis_os.h"
-
-/* as we don't include cmsis_os.h, we need to define some datatypes ourselves */
-typedef u_int8_t uint8_t;
-typedef u_int16_t uint16_t;
-typedef u_int32_t uint32_t;
+#include "cmsis_os.h"
 
 /** BASIC TYPES **/
 
@@ -33,16 +28,6 @@ typedef enum {
 typedef struct {
 	command_e command[4];
 } command_xbee_t;
-
-/* Rocket state */
-typedef enum {
-	IDLE = 1, AIRBRAKE_TEST, THRUSTING, COASTING, DESCENT, BALLISTIC_DESCENT, RECOVERY
-} flight_phase_e;
-
-/* Mach Regime */
-typedef enum {
-	SUBSONIC = 1, TRANSONIC, SUPERSONIC
-} mach_regime_e;
 
 /* Sensor type */
 typedef enum {
@@ -101,24 +86,6 @@ typedef struct  {
 	uint16_t power;
 } battery_data_t;
 
-/** CONTROL DATA TYPES **/
-
-/* State Estimation Output */
-typedef struct {
-	int32_t position_world[3];
-	int32_t velocity_rocket[3];
-	int32_t acceleration_rocket[3];
-	int32_t velocity_world[3];
-	int32_t acceleration_world[3];
-} state_est_data_t;
-
-/* FSM States */
-typedef struct {
-	flight_phase_e flight_phase;
-	mach_regime_e mach_regime;
-	float mach_number;
-	int8_t num_samples_positive;
-} flight_phase_detection_t;
 
 /** XBEE SUPER STRUCT **/
 

--- a/Inc/tasks/task_state_est.h
+++ b/Inc/tasks/task_state_est.h
@@ -14,6 +14,7 @@
 #include "Sim_Con/flight_phase_detection.h"
 #include "Sim_Con/state_est_settings.h"
 #include "Sim_Con/state_est.h"
+#include "Sim_Con/state_est_const.h"
 #include "cmsis_os.h"
 #include <stdio.h>
 #include <math.h>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# aris-euler-state-estimation
+## Usage
+The following steps need to be taken to use the state estimation:
+
+1. Initialisation and calibration for ground temperature and pressure:
+```
+state_est_state_t state_est_state = { 0 };
+reset_state_est_state(ground_pressure, ground_temperature, &state_est_state);
+```
+2. Update of state estimation measurements
+```
+state_est_state->state_est_meas = xy;
+```
+3. Update of state estimation measurements (with included flight detection step)
+```
+state_est_step(tick_count, &state_est_state, true);
+```

--- a/Src/Sim_Con/flight_phase_detection.c
+++ b/Src/Sim_Con/flight_phase_detection.c
@@ -14,6 +14,13 @@ void detect_flight_phase(flight_phase_detection_t *flight_phase_detection, state
                     flight_phase_detection->num_samples_positive = 0;
                 }
             }
+            if (((float)(state_est_data->position_world[2])) / 1000 > 80) {
+                flight_phase_detection->num_samples_positive += 1;
+                if (flight_phase_detection->num_samples_positive >= 4) {
+                    flight_phase_detection->flight_phase = THRUSTING;
+                    flight_phase_detection->num_samples_positive = 0;
+                }
+            }
         break;
 
         case THRUSTING:
@@ -38,7 +45,7 @@ void detect_flight_phase(flight_phase_detection_t *flight_phase_detection, state
 
         case DESCENT:
             /* we assume a ballistic descent when the absolute velocity of the rocket in vertical direction is larger than 40 m/s */
-            if (fabs(((float)(state_est_data->velocity_world[2])) / 1000) > 40) {
+            if (fabs(((float)(state_est_data->velocity_world[2])) / 1000) > 60) {
                 flight_phase_detection->num_samples_positive += 1;
                 if (flight_phase_detection->num_samples_positive >= 4) {
                     flight_phase_detection->flight_phase = BALLISTIC_DESCENT;
@@ -57,8 +64,9 @@ void detect_flight_phase(flight_phase_detection_t *flight_phase_detection, state
         break;
 
         case BALLISTIC_DESCENT:
-            /* we assume a touchdown event when absolute velocity of the rocket is smaller than 2 m/s */
-            if (fabs(((float)(state_est_data->velocity_rocket[0])) / 1000) < 2) {
+            /* we assume a touchdown event when the absolute value of the altitude is smaller than 500m 
+               and the absolute velocity of the rocket is smaller than 2 m/s */
+            if (fabs(((float)(state_est_data->velocity_rocket[0])) / 1000) < 2 && fabs(((float)(state_est_data->position_world[2])) / 1000) < 500) {
                 flight_phase_detection->num_samples_positive += 1;
                 if (flight_phase_detection->num_samples_positive >= 4) {
                     flight_phase_detection->flight_phase = RECOVERY;

--- a/Src/tasks/task_state_est.c
+++ b/Src/tasks/task_state_est.c
@@ -7,10 +7,6 @@
 
 #include "tasks/task_state_est.h"
 
-void resetStateEstimation(kf_state_t *kf_state, flight_phase_detection_t *flight_phase_detection,
-	env_t *environment, extrapolation_rolling_memory_t *extrapolation_rolling_memory,
-	float pressure, float temperature);
-
 
 void vTaskStateEst(void *argument) {
 
@@ -19,24 +15,10 @@ void vTaskStateEst(void *argument) {
 
 
 	/* Initialise Variables */
-	env_t env;
-	init_env(&env);
-
-	state_est_meas_t state_est_meas = { 0 };
-	state_est_meas_t state_est_meas_prior = { 0 };
-
-	kf_state_t kf_state;
-	reset_kf_state(&kf_state);
-
-	extrapolation_rolling_memory_t extrapolation_rolling_memory = { 0 };
-	extrapolation_rolling_memory.memory_length = 0;
-
-	flight_phase_detection_t flight_phase_detection = { 0 };
-	reset_flight_phase_detection(&flight_phase_detection);
+	state_est_state_t state_est_state = { 0 };
+	init_state_est_state(&state_est_state);
 
 	command_e telemetry_command = IDLE_COMMAND;
-
-	select_noise_models(&kf_state, &flight_phase_detection, &env, &extrapolation_rolling_memory);
 
 	/* average Temperature */
 	float average_temp = 0;
@@ -69,12 +51,12 @@ void vTaskStateEst(void *argument) {
 		 * to do so
 		 */
 		if (flight_phase_detection.flight_phase == IDLE && global_telemetry_command == CALIBRATE_SENSORS) {
-			resetStateEstimation(&kf_state, &flight_phase_detection, &env, &extrapolation_rolling_memory, average_press, average_temp);
+			reset_state_est_state(average_press, average_temp, &state_est_state);
 		}
 
 		/* Reset the whole thing automatically after 30 Seconds of running */
 		if (reset_counter > 30 * STATE_ESTIMATION_FREQUENCY && !was_reset) {
-			resetStateEstimation(&kf_state, &flight_phase_detection, &env, &extrapolation_rolling_memory, average_press, average_temp);
+			reset_state_est_state(average_press, average_temp, &state_est_state);
 			was_reset = true;
 		}
 		reset_counter++;
@@ -83,13 +65,13 @@ void vTaskStateEst(void *argument) {
 		/* Acquire the Sensor data */
 
 		/* Sensor Board 1 */
-		ReadMutexStateEst(&sb1_mutex, &sb1_baro, &sb1_imu, &state_est_meas, 1);
+		ReadMutexStateEst(&sb1_mutex, &sb1_baro, &sb1_imu, &state_est_state->state_est_meas, 1);
 
 		/* Sensor Board 2 */
-		ReadMutexStateEst(&sb2_mutex, &sb2_baro, &sb2_imu, &state_est_meas, 2);
+		ReadMutexStateEst(&sb2_mutex, &sb2_baro, &sb2_imu, &state_est_state->state_est_meas, 2);
 
 		/* Sensor Board 3 */
-		ReadMutexStateEst(&sb3_mutex, &sb3_baro, &sb3_imu, &state_est_meas, 3);
+		ReadMutexStateEst(&sb3_mutex, &sb3_baro, &sb3_imu, &state_est_state->state_est_meas, 3);
 
 		/* calculate averaging */
 		if (flight_phase_detection.flight_phase == IDLE) {
@@ -106,37 +88,13 @@ void vTaskStateEst(void *argument) {
 		}
 
 		/* get new Phase Detection*/
-		ReadMutex(&fsm_mutex, &global_flight_phase_detection, &flight_phase_detection, sizeof(flight_phase_detection));
+		ReadMutex(&fsm_mutex, &global_flight_phase_detection, &state_est_state->flight_phase_detection, sizeof(state_est_state->flight_phase_detection));
 
-		/* process measurements */
-		process_measurements(tick_count, &kf_state, &state_est_meas, &state_est_meas_prior, &env, &extrapolation_rolling_memory);
-
-		/* select noise models (dependent on detected flight phase and updated temperature in environment) */
-		select_noise_models(&kf_state, &flight_phase_detection, &env, &extrapolation_rolling_memory);
-
-		/* Start Kalman Update */
-
-		/* Prediction Step */
-		kf_prediction(&kf_state);
-
-		/* update Step */
-		if (kf_state.num_z_active > 0) {
-			select_kf_observation_matrices(&kf_state);
-			kf_update(&kf_state);
-		}
-		else
-		{
-			memcpy(kf_state.x_est, kf_state.x_priori, sizeof(kf_state.x_priori));
-		}
-
-		/* set measurement prior to measurements from completed state estimation step */
-		memcpy(&state_est_meas_prior, &state_est_meas, sizeof(state_est_meas));
-
-		/* Kalman Update Finished */
+		state_est_step(tick_count, &state_est_state, false);
 
 		/* Update global State Estimation Data */
 		if (AcquireMutex(&state_est_mutex) == osOK) {
-			update_state_est_data(&state_est_data_global, &kf_state);
+			update_state_est_data(&state_est_data_global, &state_est_state->kf_state);
 			ReleaseMutex(&state_est_mutex);
 		}
 
@@ -145,26 +103,13 @@ void vTaskStateEst(void *argument) {
 
 		/* Update env for FSM */
 		if (AcquireMutex(&fsm_mutex) == osOK) {
-			global_env = env;
+			global_env = state_est_state->env;
 			ReleaseMutex(&fsm_mutex);
 		}
 
 		/* Write to logging system */
 		logEstimatorVar(osKernelGetTickCount(), state_est_data_global);
 
-		/* TODO: Check if the state estimation can do this for the given frequency */
-
 		osDelayUntil(tick_count);
 	}
-}
-
-
-void resetStateEstimation(kf_state_t *kf_state, flight_phase_detection_t *flight_phase_detection,
-	env_t *environment, extrapolation_rolling_memory_t *extrapolation_rolling_memory, float pressure, float temperature) {
-	reset_flight_phase_detection(flight_phase_detection);
-	calibrate_env(environment, pressure, temperature);
-	update_env(environment, temperature);
-	reset_kf_state(kf_state);
-	*extrapolation_rolling_memory = EMPTY_MEMORY;
-	select_noise_models(kf_state, flight_phase_detection, environment, extrapolation_rolling_memory);
 }


### PR DESCRIPTION
The following steps need to be taken to use the state estimation:

1. Initialisation and calibration for ground temperature and pressure:
```
state_est_state_t state_est_state = { 0 };
reset_state_est_state(ground_pressure, ground_temperature, &state_est_state);
```
2. Update of state estimation measurements
```
state_est_state->state_est_meas = xy;
```
3. Update of state estimation measurements (with included flight detection step)
```
state_est_step(tick_count, &state_est_state, true);
```

